### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/on-mr.yml
+++ b/.github/workflows/on-mr.yml
@@ -1,4 +1,6 @@
 name: on-mr
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/dbartilson/cc_abstemious/security/code-scanning/1](https://github.com/dbartilson/cc_abstemious/security/code-scanning/1)

To fix this problem, you should explicitly add a `permissions` block to the workflow file to override defaults and restrict the GITHUB_TOKEN to the minimum permissions necessary for the workflow. Since this workflow only checks out code and runs build/lint/test steps, it suffices to add `permissions: contents: read`. This can be added at the top level in the workflow (after `name:` and before `on:`), which applies to all jobs in the workflow that lack their own `permissions`. No new imports or package changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
